### PR TITLE
[FIX] account: Fix primary key and col ordering

### DIFF
--- a/carepoint/models/cph/account.py
+++ b/carepoint/models/cph/account.py
@@ -13,14 +13,14 @@ class Account(Carepoint.BASE):
     __tablename__ = 'cp_acct'
     __dbname__ = 'cph'
 
-    ID = Column(
-        Integer,
-        primary_key=True,
-        autoincrement=False,
-    )
     pat_id = Column(
         Integer,
         ForeignKey('cppat.pat_id'),
+        primary_key=True,
+    )
+    ID = Column(
+        Integer,
+        primary_key=True,
     )
     acct_type_cn = Column(Integer)
     resp_pty_yn = Column(Integer)


### PR DESCRIPTION
* Add primary key to pat_id
* Reorder Pks to match table definition order

SQL table definition:
```
USE [cph]
GO

/****** Object:  Table [dbo].[cp_acct]    Script Date: 9/14/2016 4:17:40 PM ******/
SET ANSI_NULLS ON
GO

SET QUOTED_IDENTIFIER ON
GO

CREATE TABLE [dbo].[cp_acct](
	[pat_id] [int] NOT NULL,
	[ID] [int] NOT NULL,
	[acct_type_cn] [int] NULL,
	[resp_pty_yn] [int] NULL,
	[chromis_id] [int] NULL,
 CONSTRAINT [PK_CP_ACCT] PRIMARY KEY CLUSTERED 
(
	[pat_id] ASC,
	[ID] ASC
)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, FILLFACTOR = 90) ON [PRIMARY]
) ON [PRIMARY]

GO
```