### PR TITLE
[IMP] carepoint: Globalize models

### DIFF
--- a/carepoint/db/carepoint.py
+++ b/carepoint/db/carepoint.py
@@ -2,21 +2,31 @@
 # Copyright 2016-TODAY LasLabs Inc.
 # License MIT (https://opensource.org/licenses/MIT).
 
-import os
 import imp
 import operator
+import os
 import urllib2
-from sqlalchemy import text, bindparam
+
+from contextlib import contextmanager
+
+from sqlalchemy import bindparam
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy.inspection import inspect
-from smb.SMBHandler import SMBHandler
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import text
+
+
 from .db import Db
+from smb.SMBHandler import SMBHandler
+
 
 Base = declarative_base()
 Base.get = lambda s, k, v=None: getattr(s, k, v)
 Base.__getitem__ = lambda s, k, v=None: getattr(s, k, v)
 Base.__setitem__ = lambda s, k, v: setattr(s, k, v)
+
+
+models, env, dbs = {}, {}, {}
 
 
 class Carepoint(dict):
@@ -37,11 +47,29 @@ class Carepoint(dict):
         '==': operator.eq,
     }
 
-    def __init__(self, server, user, passwd, smb_user=None, smb_passwd=None,
-                 db_args=None,
-                 ):
+    def __init__(
+        self, server, user, passwd, smb_user=None, smb_passwd=None,
+        db_args=None, **engine_args
+    ):
+        """ It initializes new Carepoint object
+
+        Args:
+            server (str): IP or Hostname to database
+            user (str): Username for database
+            passwd (str): Password for database
+            smb_user (str): Username to use for SMB connection, ``None`` to
+                use the database user
+            smd_passwd (str): Password to use for the SMB connection, ``None``
+                to use the database password
+            db_args (dict): Dictionary of arguments to send during initial
+                db creation
+            **engine_args (mixed): Kwargs to pass to ``create_engine``
+        """
 
         super(Carepoint, self).__init__()
+        global env, dbs
+        self.env = env
+        self.dbs = dbs
         self.iter_refresh = False
         params = {
             'user': user,
@@ -51,14 +79,13 @@ class Carepoint(dict):
         }
         if db_args is not None:
             params.update(db_args)
+        if engine_args:
+            params.update(engine_args)
         # @TODO: Lazy load, once other dbs needed
-        self.dbs = {
-            'cph': Db(**params),
-        }
-        self.env = {
-            'cph': sessionmaker(bind=self.dbs['cph']),
-        }
-        self.sessions = {}
+        if not self.dbs.get('cph'):
+            self.dbs['cph'] = Db(**params)
+        if not self.env.get('cph'):
+            self.env['cph'] = sessionmaker(bind=self.dbs['cph'])
         if smb_user is None:
             self.smb_creds = {
                 'user': user,
@@ -66,17 +93,21 @@ class Carepoint(dict):
             }
         else:
             self.smb_creds = {
-                'user': user,
-                'passwd': passwd,
+                'user': smb_user,
+                'passwd': smb_passwd,
             }
 
+    @contextmanager
     def _get_session(self, model_obj):
+        session = self.env[model_obj.__dbname__]()
         try:
-            return self.sessions[model_obj.__dbname__]
-        except KeyError:
-            session = self.env[model_obj.__dbname__]()
-            self.sessions[model_obj.__dbname__] = session
-            return session
+            yield session
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     @property
     def _smb_prefix(self):
@@ -181,30 +212,6 @@ class Carepoint(dict):
                 pass
         return out
 
-    def _do_queries(self, session, *queries, **kwargs):
-        """ Wrapper method for running any query against the DB safely
-        Will create a transaction, then loop and run `queries` methods
-        :param model_obj: Table class to search
-        :type model_obj: :class:`sqlalchemy.Table`
-        :param queries: Query method(s) to be run in context of transaction
-        :type queries: Methods to be run against db
-        :kwarg no_commit: True to not commit transaction
-        :returns: Query result(s)
-        :rtype: ResultProxy if singleton, else List of ResultProxies
-        """
-        res = []
-        try:
-            for query in queries:
-                res.append(query())
-            if not kwargs.get('no_commit'):
-                session.commit()
-        except:
-            session.rollback()
-            raise
-        if len(res) == 1:
-            return res[0]
-        return res
-
     def read(self, model_obj, record_id, with_entities=None):
         """ Get record by id and return the object
         :param model_obj: Table class to search
@@ -216,16 +223,12 @@ class Carepoint(dict):
         :type with_entities: list or None
         :rtype: :class:`sqlalchemy.engine.ResultProxy`
         """
-        session = self._get_session(model_obj)
-        res = self._do_queries(
-            session,
-            lambda: session.query(model_obj).get(record_id),
-            no_commit=True,
-        )
-        if with_entities:
-            res.with_entities(*self._create_entities(
-                model_obj, with_entities
-            ))
+        with self._get_session(model_obj) as session:
+            res = session.query(model_obj).get(record_id)
+            if with_entities:
+                res.with_entities(*self._create_entities(
+                    model_obj, with_entities
+                ))
         return res
 
     def search(self, model_obj, filters=None, with_entities=None):
@@ -238,18 +241,15 @@ class Carepoint(dict):
         :type with_entities: list or None
         :rtype: :class:`sqlalchemy.engine.ResultProxy`
         """
-        session = self._get_session(model_obj)
-        if filters is None:
-            filters = {}
-        filters = self._unwrap_filters(model_obj, filters)
-        res = self._do_queries(
-            session,
-            lambda: session.query(model_obj).filter(*filters),
-        )
-        if with_entities:
-            res.with_entities(*self._create_entities(
-                model_obj, with_entities
-            ))
+        with self._get_session(model_obj) as session:
+            if filters is None:
+                filters = {}
+            filters = self._unwrap_filters(model_obj, filters)
+            res =  session.query(model_obj).filter(*filters)
+            if with_entities:
+                res.with_entities(*self._create_entities(
+                    model_obj, with_entities
+                ))
         return res
 
     def create(self, model_obj, vals):
@@ -260,14 +260,10 @@ class Carepoint(dict):
         :type vals: dict
         :rtype: :class:`sqlalchemy.ext.declarative.Declarative`
         """
-        session = self._get_session(model_obj)
-
-        def __create():
+        with self._get_session(model_obj) as session:
             record = model_obj(**vals)
             session.add(record)
-            return record
-
-        return self._do_queries(session, __create)
+        return record
 
     def update(self, model_obj, record_id, vals):
         """ Wrapper to update a record in Carepoint
@@ -279,16 +275,11 @@ class Carepoint(dict):
         :type vals: dict
         :rtype: :class:`sqlalchemy.ext.declarative.Declarative`
         """
-
-        session = self._get_session(model_obj)
-
-        def __update():
+        with self._get_session(model_obj) as session:
             record = self.read(model_obj, record_id)
             for key, val in vals.items():
                 setattr(record, key, val)
-            return record
-
-        return self._do_queries(session, __update)
+        return record
 
     def delete(self, model_obj, record_id):
         """ Wrapper to delete a record in Carepoint
@@ -299,19 +290,14 @@ class Carepoint(dict):
         :return: Whether the record was found, and deleted
         :rtype: bool
         """
-
-        session = self._get_session(model_obj)
-
-        def __delete():
+        with self._get_session(model_obj) as session:
             record = self.read(model_obj, record_id)
             result_cnt = record.count()
             if result_cnt == 0:
                 return False
             assert result_cnt == 1
             session.delete(record)
-            return True
-
-        return self._do_queries(session, __delete)
+        return True
 
     def get_pks(self, model_obj):
         """ Return the Primary keys in the model
@@ -362,8 +348,18 @@ class Carepoint(dict):
             except KeyError:
                 raise AttributeError()
 
+    def __setitem__(self, key, val, __global=False, *args, **kwargs):
+        """ Re-implement __setitem__ to allow for global model sync """
+        super(Carepoint, self).__setitem__(key, val, *args, **kwargs)
+        if not __global:
+            global models
+            models[key] = val
+
     def __getitem__(self, key, retry=True, default=False):
         """ Re-implement __getitem__ to scan for models if key missing  """
+        global models
+        for k, v in models.iteritems():
+            self.__setitem__(k, v, True)
         try:
             return super(Carepoint, self).__getitem__(key)
         except KeyError:

--- a/carepoint/db/db.py
+++ b/carepoint/db/db.py
@@ -12,8 +12,24 @@ class Db(object):
     ODBC_DRIVER = 'FreeTDS&TDS_VERSION=8.0'
     SQLITE = 'sqlite'
 
-    def __new__(self, server=None, user=None, passwd=None,
-                db=None, port=1433, drv=ODBC_DRIVER, ):
+    def __new__(
+        self, server=None, user=None, passwd=None, db=None, port=1433,
+        drv=ODBC_DRIVER, **engine_args
+    ):
+        """ It establishes a new database connection and returns engine
+
+        Args:
+            server (str): IP or Hostname to database
+            user (str): Username for database
+            passwd (str): Password for database
+            db (str): Name of database
+            port (int): Connection port
+            drv (str): Name of underlying database driver for connection
+            **engine_args (mixed): Kwargs to pass to ``create_engine``
+
+        Return:
+            sqlalchemy.engine.Engine
+        """
 
         if drv != self.SQLITE:
             params = {
@@ -25,7 +41,7 @@ class Db(object):
                 'prt': port,
             }
             dsn = 'mssql+pyodbc://{usr}:{pass}@{srv}:{prt}/{db}?driver={drv}'
-            return create_engine(dsn.format(**params))
+            return create_engine(dsn.format(**params), **engine_args)
 
         else:
-            return create_engine('%s://' % self.SQLITE)
+            return create_engine('%s://' % self.SQLITE, **engine_args)

--- a/carepoint/tests/db/test_carepoint.py
+++ b/carepoint/tests/db/test_carepoint.py
@@ -5,6 +5,8 @@
 import os
 import unittest
 import mock
+from contextlib import contextmanager
+
 from carepoint import Carepoint
 
 
@@ -33,6 +35,15 @@ class CarepointTest(unittest.TestCase):
         model_obj = self.carepoint['TestModel']
         return model_obj
 
+    @contextmanager
+    def __get_mock_session(self, unwrapped=True):
+        with mock.patch.object(self.carepoint, '_get_session') as mk:
+            enter, session = mock.MagicMock(), mock.MagicMock()
+            enter.return_value = enter
+            mk.return_value = session
+            session.__enter__.return_value = enter
+            yield enter if unwrapped else mk
+
     #
     # Test Initializations and other core stuff
     #
@@ -53,17 +64,15 @@ class CarepointTest(unittest.TestCase):
             self.carepoint.iter_refresh
         )
 
-    @mock.patch('carepoint.db.carepoint.Db')
-    @mock.patch('carepoint.db.carepoint.sessionmaker')
-    def test_carepoint_assigns_instance_env(self, sess_mk, db_mk):
-        cp = Carepoint(**self.cp_args)
-        self.assertEqual(
-            sess_mk(), cp.env['cph'],
+    def test_carepoint_assigns_instance_env(self):
+        self.assertTrue(
+            self.carepoint.env['cph'],
         )
 
     def test_cph_db_init(self):
-        self.cp_args['db'] = 'cph'
-        self.db_mock.assert_called_once_with(**self.cp_args)
+        self.assertTrue(
+            self.carepoint.dbs['cph']
+        )
 
     def test_cph_db_assign(self):
         self.carepoint.dbs['cph'] = self.db_mock
@@ -93,6 +102,54 @@ class CarepointTest(unittest.TestCase):
         self.carepoint.set_iter_refresh()
         model_obj = self.carepoint['TestModel']
         self.assertTrue(model_obj.run())  # < classmethods are exposed
+
+    #
+    # Test the session handler
+    #
+
+    def test_get_session_gets_session(self):
+        """ It should get session for the database """
+        model_obj = self.__get_model_obj()
+        with mock.patch.object(self.carepoint, 'env') as env:
+            with self.carepoint._get_session(model_obj):
+                pass
+            env[model_obj.__dbname__].assert_called_once_with()
+
+    def test_get_session_yields_session(self):
+        """ It should yield session for the database """
+        model_obj = self.__get_model_obj()
+        with mock.patch.object(self.carepoint, 'env') as env:
+            with self.carepoint._get_session(model_obj) as res:
+                self.assertEqual(
+                    env[model_obj.__dbname__](),
+                    res,
+                )
+
+    def test_get_session_commit(self):
+        """ It should commit session after yield """
+        model_obj = self.__get_model_obj()
+        with mock.patch.object(self.carepoint, 'env') as env:
+            with self.carepoint._get_session(model_obj):
+                pass
+            env[model_obj.__dbname__]().commit.assert_called_once_with()
+
+    def test_get_session_rollback(self):
+        """ It should roll session back on error """
+        model_obj = self.__get_model_obj()
+        with mock.patch.object(self.carepoint, 'env') as env:
+            env[model_obj.__dbname__]().commit.side_effect = EndTestException
+            with self.assertRaises(EndTestException):
+                with self.carepoint._get_session(model_obj):
+                    pass
+            env[model_obj.__dbname__]().rollback.assert_called_once_with()
+
+    def test_get_session_close(self):
+        """ It should always close session """
+        model_obj = self.__get_model_obj()
+        with mock.patch.object(self.carepoint, 'env') as env:
+            with self.carepoint._get_session(model_obj):
+                pass
+            env[model_obj.__dbname__]().close.assert_called_once_with()
 
     #
     # Test the SMB handlers
@@ -163,16 +220,14 @@ class CarepointTest(unittest.TestCase):
     def test_read_calls_query_with_model_obj(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             self.carepoint.read(model_obj, record_id)
             mk.query.assert_called_once_with(model_obj)
 
     def test_read_calls_get_with_record_id(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             mk.query.return_value = query_mk = mock.MagicMock()
             self.carepoint.read(model_obj, record_id)
             query_mk.get.assert_called_once_with(record_id)
@@ -181,8 +236,7 @@ class CarepointTest(unittest.TestCase):
         model_obj = self.__get_model_obj()
         record_id = 1
         expect = 'Response'
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             mk.query.return_value = query_mk = mock.MagicMock()
             query_mk.get.return_value = expect
             response = self.carepoint.read(model_obj, record_id)
@@ -190,18 +244,16 @@ class CarepointTest(unittest.TestCase):
 
     # Search
     def test_search_calls_query_with_model_obj(self):
-        model_obj = self.__get_model_obj()
         filters = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
+            model_obj = self.__get_model_obj()
             self.carepoint.search(model_obj, filters)
             mk.query.assert_called_once_with(model_obj)
 
     def test_search_calls_filter_with_filters(self):
         model_obj = self.__get_model_obj()
         filters = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             mk.query.return_value = query_mk = mock.MagicMock()
             self.carepoint.search(model_obj, filters)
             query_mk.filter.assert_called_once_with(
@@ -210,8 +262,7 @@ class CarepointTest(unittest.TestCase):
 
     def test_search_calls_filter_when_no_filters(self):
         model_obj = self.__get_model_obj()
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             mk.query.return_value = query_mk = mock.MagicMock()
             self.carepoint.search(model_obj)
             query_mk.filter.assert_called_once_with(**{})
@@ -219,13 +270,13 @@ class CarepointTest(unittest.TestCase):
     def test_search_returns_response(self):
         model_obj = self.__get_model_obj()
         filters = {'test_col': 'Test'}
-        expect = 'Response'
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
-            mk.query.return_value = query_mk = mock.MagicMock()
-            query_mk.get.return_value = expect
-            response = self.carepoint.read(model_obj, filters)
-            self.assertEqual(response, expect)
+        with self.__get_mock_session() as mk:
+            with mock.patch.object(self.carepoint, 'read') as read_mk:
+                response = self.carepoint.read(model_obj, filters)
+                self.assertEqual(
+                    read_mk(),
+                    response,
+                )
 
     # Get Next Sequence
     def test_get_next_sequence_connect(self):
@@ -287,18 +338,16 @@ class CarepointTest(unittest.TestCase):
             dbs['cph'].connect().close.assert_called_once_with()
 
     # Create
-    def test_create_calls__get_session_with_model_obj(self):
-        model_obj = self.__get_model_obj()
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+    def test_create_calls_get_session_with_model_obj(self):
+        model_obj = mock.MagicMock()
+        with self.__get_mock_session(False) as mk:
             self.carepoint.create(model_obj, {})
             mk.assert_called_once_with(model_obj)
 
     def test_create_initializes_new_model_obj_with_vals(self):
         model_obj = mock.MagicMock()
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             self.carepoint.create(model_obj, vals)
             model_obj.assert_called_once_with(**vals)
 
@@ -307,26 +356,16 @@ class CarepointTest(unittest.TestCase):
         response_expect = 'ResponseExpect'
         model_obj.return_value = response_expect
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             self.carepoint.create(model_obj, vals)
             mk.add.assert_called_once_with(response_expect)
-
-    def test_create_calls_commit_on_session(self):
-        model_obj = mock.MagicMock()
-        vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
-            self.carepoint.create(model_obj, vals)
-            mk.commit.assert_called_once_with()
 
     def test_create_returns_new_record(self):
         model_obj = mock.MagicMock()
         response_expect = 'ResponseExpect'
         model_obj.return_value = response_expect
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             response = self.carepoint.create(model_obj, vals)
             self.assertEqual(response, response_expect)
 
@@ -334,7 +373,7 @@ class CarepointTest(unittest.TestCase):
     def test_update_calls_get_session_with_model_obj(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
+        with self.__get_mock_session(False) as mk:
             with mock.patch.object(self.carepoint, 'read'):
                 self.carepoint.update(model_obj, record_id, {})
                 mk.assert_called_once_with(model_obj)
@@ -343,7 +382,7 @@ class CarepointTest(unittest.TestCase):
         model_obj = self.__get_model_obj()
         record_id = 1
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session'):
+        with self.__get_mock_session():
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 self.carepoint.update(model_obj, record_id, vals)
                 read_mk.assert_called_once_with(model_obj, record_id)
@@ -352,41 +391,32 @@ class CarepointTest(unittest.TestCase):
         model_obj = self.__get_model_obj()
         record_id = 1
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             mk.query.return_value = query_mk = mock.MagicMock()
             query_mk.get.return_value = get_mk = mock.MagicMock()
             self.carepoint.update(model_obj, record_id, vals)
             self.assertEqual(
-                vals['test_col'], get_mk.test_col,
+                mk().query().get().test_col,
+                get_mk.test_col,
                 'Record attribute was not updated. Expect Test, Got %s' % (
                     get_mk.test_col,
                 )
             )
 
-    def test_update_calls_commit_on_session(self):
-        model_obj = mock.MagicMock()
-        record_id = 1
-        vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
-            self.carepoint.update(model_obj, record_id, vals)
-            mk.commit.assert_called_once_with()
-
     def test_update_returns_record(self):
-        model_obj = mock.MagicMock()
+        model_obj = self.__get_model_obj()
         record_id = 1
         vals = {'test_col': 'Test'}
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
-            response = self.carepoint.update(model_obj, record_id, vals)
-            self.assertEqual(response, mk.query().get())
+        with self.__get_mock_session() as mk:
+            with mock.patch.object(self.carepoint, 'read') as read:
+                response = self.carepoint.update(model_obj, record_id, vals)
+                self.assertEqual(read(), response)
 
     # Delete
     def test_delete_calls_get_session_with_model_obj(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
+        with self.__get_mock_session(False) as mk:
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = read_mk
                 read_mk.count.return_value = 0
@@ -396,7 +426,7 @@ class CarepointTest(unittest.TestCase):
     def test_delete_calls_read_with_model_and_record_id(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session'):
+        with self.__get_mock_session():
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = read_mk
                 read_mk.count.return_value = 0
@@ -406,7 +436,7 @@ class CarepointTest(unittest.TestCase):
     def test_delete_asserts_result_count_eq_1(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session'):
+        with self.__get_mock_session():
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = read_mk
                 read_mk.count.return_value = 2
@@ -417,29 +447,17 @@ class CarepointTest(unittest.TestCase):
         model_obj = self.__get_model_obj()
         record_id = 1
         expect_return = mock.MagicMock()
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
+        with self.__get_mock_session() as mk:
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = expect_return
                 expect_return.count.return_value = 1
                 self.carepoint.delete(model_obj, record_id)
                 mk.delete.assert_called_once_with(expect_return)
 
-    def test_delete_calls_session_commit(self):
-        model_obj = self.__get_model_obj()
-        record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            mk.return_value = mk
-            with mock.patch.object(self.carepoint, 'read') as read_mk:
-                read_mk.return_value = read_mk
-                read_mk.count.return_value = 1
-                self.carepoint.delete(model_obj, record_id)
-                mk.commit.assert_called_once_with()
-
     def test_delete_returns_false_on_no_records(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session'):
+        with self.__get_mock_session():
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = read_mk
                 read_mk.count.return_value = 0
@@ -449,23 +467,12 @@ class CarepointTest(unittest.TestCase):
     def test_delete_returns_true_on_delete(self):
         model_obj = self.__get_model_obj()
         record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session'):
+        with self.__get_mock_session():
             with mock.patch.object(self.carepoint, 'read') as read_mk:
                 read_mk.return_value = read_mk
                 read_mk.count.return_value = 1
                 response = self.carepoint.delete(model_obj, record_id)
                 self.assertTrue(response)
-
-    def test_delete_calls_commit_on_session(self):
-        model_obj = mock.MagicMock()
-        record_id = 1
-        with mock.patch.object(self.carepoint, '_get_session') as mk:
-            with mock.patch.object(self.carepoint, 'read') as read_mk:
-                read_mk.return_value = read_mk
-                read_mk.count.return_value = 1
-                mk.return_value = mk
-                self.carepoint.delete(model_obj, record_id)
-                mk.commit.assert_called_once_with()
 
     #
     # Test filter criterion generators

--- a/carepoint/tests/db/test_models/test_model.py
+++ b/carepoint/tests/db/test_models/test_model.py
@@ -5,6 +5,7 @@
 
 class TestModel(object):
     __tablename__ = '__test__'
+    __dbname__ = 'cph'
     test_col = 'Test'
 
     @classmethod


### PR DESCRIPTION
It provides better globalized session handling in order to allow for database connections in threaded environments.

* Create and use global models obj to hold instantiated declaratives