### PR TITLE
[FIX] carepoint: Enum handling

### DIFF
--- a/carepoint/models/address_mixin.py
+++ b/carepoint/models/address_mixin.py
@@ -8,8 +8,8 @@ from sqlalchemy import (Column,
                         Integer,
                         DateTime,
                         ForeignKey,
-                        Enum,
                         )
+from sqlalchemy.types import Enum
 from sqlalchemy.ext.declarative import declared_attr
 
 
@@ -29,9 +29,7 @@ class AddressMixin(object):
     """ This is a mixin for Address Many2Many bindings """
 
     priority = Column(Integer)
-    addr_type_cn = Column(
-        Enum(EnumAddressType),
-    )
+    addr_type_cn = Column(Integer)
     app_flags = Column(Integer)
     timestmp = Column(DateTime)
 
@@ -42,3 +40,7 @@ class AddressMixin(object):
             ForeignKey('csaddr.addr_id'),
             primary_key=True,
         )
+
+    @property
+    def addr_type(self):
+        return EnumAddressType(self.addr_type_cn)

--- a/carepoint/models/cph/order.py
+++ b/carepoint/models/cph/order.py
@@ -28,7 +28,7 @@ class Order(Carepoint.BASE):
     acct_id = Column(Integer)
     invoice_nbr = Column(Integer)
     order_state_cn = Column(
-        Enum(EnumOrderState),
+        Integer,
         ForeignKey('CsOmStatus.state_cn')
     )
     order_status_cn = Column(
@@ -88,3 +88,7 @@ class Order(Carepoint.BASE):
         ForeignKey('csuser.user_id'),
     )
     chg_date = Column(DateTime)
+
+    @property
+    def order_state(self):
+        return EnumOrderState(self.order_state_cn)

--- a/carepoint/models/cph/order_status.py
+++ b/carepoint/models/cph/order_status.py
@@ -22,6 +22,10 @@ class OrderStatus(Carepoint.BASE):
         autoincrement=False,
     )
     state_cn = Column(
-        Enum(EnumOrderState)
+        Integer,
     )
     descr = Column(String)
+
+    @property
+    def state(self):
+        return EnumOrderState(self.state_cn)

--- a/carepoint/models/phone_mixin.py
+++ b/carepoint/models/phone_mixin.py
@@ -8,8 +8,8 @@ from sqlalchemy import (Column,
                         Integer,
                         DateTime,
                         ForeignKey,
-                        Enum,
                         )
+from sqlalchemy.types import Enum
 from sqlalchemy.ext.declarative import declared_attr
 
 
@@ -33,9 +33,7 @@ class PhoneMixin(object):
     """ This is a mixin for Phone Many2Many bindings """
 
     priority = Column(Integer)
-    phone_type_cn = Column(
-        Enum(EnumPhoneType),
-    )
+    phone_type_cn = Column(Integer)
     app_flags = Column(Integer)
     timestmp = Column(DateTime)
 
@@ -46,3 +44,7 @@ class PhoneMixin(object):
             ForeignKey('csphone.phone_id'),
             primary_key=True,
         )
+
+    @property
+    def phone_type(self):
+        return EnumPhoneType(self.phone_type_cn)

--- a/carepoint/tests/models/cph/test_doctor_address.py
+++ b/carepoint/tests/models/cph/test_doctor_address.py
@@ -18,5 +18,6 @@ class TestModelsCphDoctorAddress(DatabaseTest):
             hasattr(DoctorAddress, 'addr_id')
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/carepoint/tests/models/cph/test_order.py
+++ b/carepoint/tests/models/cph/test_order.py
@@ -5,13 +5,27 @@
 import unittest
 from sqlalchemy.schema import Table
 from carepoint.tests.db.db import DatabaseTest
-from carepoint.models.cph.order import Order
+from carepoint.models.cph.order import Order, EnumOrderState
 
 
 class TestModelsCphOrder(DatabaseTest):
 
     def test_table_initialization(self, ):
         self.assertIsInstance(Order.__table__, Table)
+
+    def new_record(self):
+        self.type_cn = 20
+        obj = Order()
+        obj.order_state_cn = self.type_cn
+        return obj
+
+    def test_order_state(self):
+        """ It should return proper Enum for state cn """
+        obj = self.new_record()
+        self.assertEqual(
+            EnumOrderState(self.type_cn),
+            obj.order_state,
+        )
 
 
 if __name__ == '__main__':

--- a/carepoint/tests/models/cph/test_order_status.py
+++ b/carepoint/tests/models/cph/test_order_status.py
@@ -5,13 +5,27 @@
 import unittest
 from sqlalchemy.schema import Table
 from carepoint.tests.db.db import DatabaseTest
-from carepoint.models.cph.order_status import OrderStatus
+from carepoint.models.cph.order_status import OrderStatus, EnumOrderState
 
 
 class TestModelsCphOrderStatus(DatabaseTest):
 
     def test_table_initialization(self, ):
         self.assertIsInstance(OrderStatus.__table__, Table)
+
+    def new_record(self):
+        self.type_cn = 20
+        obj = OrderStatus()
+        obj.state_cn = self.type_cn
+        return obj
+
+    def test_state(self):
+        """ It should return proper Enum for state cn """
+        obj = self.new_record()
+        self.assertEqual(
+            EnumOrderState(self.type_cn),
+            obj.state,
+        )
 
 
 if __name__ == '__main__':

--- a/carepoint/tests/models/test_address_mixin.py
+++ b/carepoint/tests/models/test_address_mixin.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-TODAY LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+import unittest
+from sqlalchemy.schema import Table
+from carepoint.tests.db.db import DatabaseTest
+from carepoint.models.address_mixin import AddressMixin, EnumAddressType
+
+
+class TestAddressMixin(DatabaseTest):
+
+    def setUp(self):
+        super(TestAddressMixin, self).setUp()
+        self.type_cn = 2
+        self.obj = AddressMixin()
+        self.obj.addr_type_cn = self.type_cn
+
+    def test_addr_type(self):
+        """ It should return proper Enum for type cn """
+        self.assertEqual(
+            EnumAddressType(self.type_cn),
+            self.obj.addr_type,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/carepoint/tests/models/test_phone_mixin.py
+++ b/carepoint/tests/models/test_phone_mixin.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-TODAY LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+import unittest
+from sqlalchemy.schema import Table
+from carepoint.tests.db.db import DatabaseTest
+from carepoint.models.phone_mixin import PhoneMixin, EnumPhoneType
+
+
+class TestPhoneMixin(DatabaseTest):
+
+    def setUp(self):
+        super(TestPhoneMixin, self).setUp()
+        self.type_cn = 2
+        self.obj = PhoneMixin()
+        self.obj.phone_type_cn = self.type_cn
+
+    def test_addr_type(self):
+        """ It should return proper Enum for type cn """
+        self.assertEqual(
+            EnumPhoneType(self.type_cn),
+            self.obj.phone_type,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from tests import Tests
 
 setup_vals = {
     'name': 'carepoint',
-    'version': '0.1.4',
+    'version': '0.1.5',
     'author': 'LasLabs Inc.',
     'author_email': 'support@laslabs.com',
     'description': 'This library will allow you to interact with CarePoint '


### PR DESCRIPTION
* SQLalchemy Enums use string & the key instead of the val - so won't work. Create proxy for:
  * PhoneMixin
  * AddressMixin
  * Order
  * OrderState