### PR TITLE
[FIX] carepoint: Fix sequence generation

### DIFF
--- a/carepoint/db/carepoint.py
+++ b/carepoint/db/carepoint.py
@@ -326,7 +326,7 @@ class Carepoint(dict):
             Integer to use as pk
         """
         with self._get_session(db_name) as session:  
-            res = session.execute(
+            res = session.connection().execute(
                 text(
                     "SET NOCOUNT ON;"
                     "DECLARE @out int = 0;"

--- a/carepoint/tests/db/test_carepoint.py
+++ b/carepoint/tests/db/test_carepoint.py
@@ -293,7 +293,7 @@ class CarepointTest(unittest.TestCase):
         expect = 'expect'
         with mock.patch.object(self.carepoint, '_get_session') as mk:
             self.carepoint.get_next_sequence(expect)
-            mk().__enter__().execute.assert_called_once_with(
+            mk().__enter__().connection().execute.assert_called_once_with(
                 text(), seq_name=expect,
             )
 
@@ -301,7 +301,7 @@ class CarepointTest(unittest.TestCase):
         """ It should return result of fetch """
         with mock.patch.object(self.carepoint, '_get_session') as mk:
             res = self.carepoint.get_next_sequence(None)
-            expect = mk().__enter__().execute().fetchall()[0][0]
+            expect = mk().__enter__().connection().execute().fetchall()[0][0]
             self.assertEqual(
                 expect, res,
             )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from tests import Tests
 
 setup_vals = {
     'name': 'carepoint',
-    'version': '0.1.5',
+    'version': '0.1.6',
     'author': 'LasLabs Inc.',
     'author_email': 'support@laslabs.com',
     'description': 'This library will allow you to interact with CarePoint '


### PR DESCRIPTION
* Call execute directly on connection to allow params

Before:

```
>>> cp = Carepoint(
...     server='10.0.13.73',
...     user='test_odoo',
...     passwd='',
... )
>>> cp.get_next_sequence('pat_id')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "carepoint/db/carepoint.py", line 338, in get_next_sequence
    seq_name=sequence_name,
  File "/root/_venv/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1104, in execute
    bind = self.get_bind(mapper, clause=clause, **kw)
TypeError: get_bind() got an unexpected keyword argument 'seq_name'
```

After:

```
>>> cp = Carepoint(
...     server='10.0.13.73',
...     user='test_odoo',
...     passwd='',
... )
>>> cp.get_next_sequence('pat_id')
1103
```