### PR TITLE
[IMP] Add bindings for `cpimage_data` model

### DIFF
--- a/carepoint/models/cph/image_data.py
+++ b/carepoint/models/cph/image_data.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-TODAY LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+from carepoint import Carepoint
+from sqlalchemy import (Column,
+                        DateTime,
+                        ForeignKey,
+                        Integer,
+                        String,
+                        Numeric,
+                        )
+
+
+class ImageData(Carepoint.BASE):
+    __tablename__ = 'cpimage_data'
+    __dbname__ = 'cph'
+
+    image_id = Column(
+        Integer,
+        # Column is not actually a primary key in DB.
+        primary_key=True,
+    )
+    image_type_cn = Column(
+        Integer,
+    )
+    related_id = Column(
+        Integer,
+        # Column is not actually a primary key in DB.
+        primary_key=True,
+    )
+    RootFolderName = Column(
+        String,
+    )
+    FullFileName = Column(
+        String,
+    )
+    related_store_id = Column(
+        Integer,
+        ForeignKey('csstore.store_id'),
+    )
+    related_pat_id = Column(
+        Integer,
+        ForeignKey('cppat.pat_id'),
+    )
+    add_user_id = Column(
+        Integer,
+        ForeignKey('csuser.user_id'),
+    )
+    add_date = Column(DateTime)
+    chg_user_id = Column(
+        Integer,
+        ForeignKey('csuser.user_id'),
+    )
+    chg_date = Column(DateTime)
+    image_path = property(lambda s: s._compute_image_path())
+
+    def _compute_image_path(self):
+        return '%s/%s' % (self.RootFolderName, self.FullFileName)

--- a/carepoint/tests/models/cph/test_image_data.py
+++ b/carepoint/tests/models/cph/test_image_data.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-TODAY LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+import unittest
+from sqlalchemy.schema import Table
+from carepoint.tests.db.db import DatabaseTest
+from carepoint.models.cph.image_data import ImageData
+
+
+class TestImageData(DatabaseTest):
+
+    def test_table_initialization(self):
+        self.assertIsInstance(ImageData.__table__, Table)
+
+    def test_compute_image_path(self):
+        image = ImageData(
+            RootFolderName='root',
+            FullFileName='file',
+        )
+        self.assertEqual(image.image_path, 'root/file')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Create `ImageData` to bind to `cpimage_data` table
* Add `image_path` with a computational method to join the root folder and file name