### PR TITLE
[IMP] Add image type enum and property in image_data

### DIFF
--- a/carepoint/models/cph/image_data.py
+++ b/carepoint/models/cph/image_data.py
@@ -11,6 +11,8 @@ from sqlalchemy import (Column,
                         Numeric,
                         )
 
+from ..enum_image_type import EnumImageType
+
 
 class ImageData(Carepoint.BASE):
     __tablename__ = 'cpimage_data'
@@ -55,5 +57,11 @@ class ImageData(Carepoint.BASE):
     chg_date = Column(DateTime)
     image_path = property(lambda s: s._compute_image_path())
 
+    @property
+    def image_type(self):
+        """Return the canonical name for the image type."""
+        return EnumImageType(self.image_type_cn).name
+
     def _compute_image_path(self):
+        """Return the full network path for the image."""
         return '%s/%s' % (self.RootFolderName, self.FullFileName)

--- a/carepoint/models/enum_image_type.py
+++ b/carepoint/models/enum_image_type.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-TODAY LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+import enum
+
+from sqlalchemy import (Column,
+                        Integer,
+                        DateTime,
+                        ForeignKey,
+                        )
+from sqlalchemy.types import Enum
+from sqlalchemy.ext.declarative import declared_attr
+
+
+class EnumImageType(enum.Enum):
+    """Provide a PEP-0435 compliant Carepoint Image Type Enumerable."""
+
+    prescription = 2
+    unknown_3 = 3
+    unknown_7 = 7
+    unknown_1001 = 1001

--- a/carepoint/tests/models/cph/test_image_data.py
+++ b/carepoint/tests/models/cph/test_image_data.py
@@ -14,11 +14,19 @@ class TestImageData(DatabaseTest):
         self.assertIsInstance(ImageData.__table__, Table)
 
     def test_compute_image_path(self):
+        """It should return the full image path."""
         image = ImageData(
             RootFolderName='root',
             FullFileName='file',
         )
         self.assertEqual(image.image_path, 'root/file')
+
+    def test_image_type(self):
+        """It should return the canonical name for the type."""
+        image = ImageData(
+            image_type_cn=2,
+        )
+        self.assertEqual(image.image_type, 'prescription')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add an enum for the image types. Currently mapped are the distinct values from an existing prod, with the one known value filled (prescription). Pending response from CP on others
* Add `image_type` computed property in `image_data` that maps the type code using the enum